### PR TITLE
Fix for issue #18: Handle response decompression

### DIFF
--- a/src/TwitterDump/Twitter.cs
+++ b/src/TwitterDump/Twitter.cs
@@ -113,9 +113,13 @@ namespace TwitterDump
             nextCursor = null;
             string cursor = null;
             var hasEntries = false;
-            
-            
-            using (var http = new HttpClient())
+
+            HttpClientHandler handler = new HttpClientHandler()
+            {
+                AutomaticDecompression = DecompressionMethods.All
+            };
+
+            using (var http = new HttpClient(handler))
             {
                 foreach (var header in headers)
                 {


### PR DESCRIPTION
Twitter compresses the response, which makes the json deserialization fail as it is trying to deserialize binary data. I guess they didn't used to do this.
This simple PR adds automatic decompression to the http client.
See #18 